### PR TITLE
path fix for makefile10

### DIFF
--- a/makefile10
+++ b/makefile10
@@ -1,5 +1,4 @@
-HOMEDIR = $(shell pwd)/../..
-PRJHOME = $(HOMEDIR)/CuProjs/GCTFFind
+PRJHOME = $(shell pwd)
 CUDAHOME = $(HOME)/nvidia/cuda-10.2
 CUDAINC = $(CUDAHOME)/include
 CUDALIB = $(CUDAHOME)/lib64


### PR DESCRIPTION
Verified that code can be compiled with both makefiles and the `./GCtfFind --version` command worked after. For makefile10, a small path fix was required.